### PR TITLE
more CI cleanup; all CI workflows are required to pass before merge to develop

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -18,15 +18,11 @@ defaults:
     shell: bash -leo pipefail {0}
 
 jobs:
-  intel-build-and-test:
+  Intel:
     runs-on: ubuntu-latest
     env:
       CC: icc
       FC: ifort
-      CXX: icpc
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
 
     steps:
 
@@ -54,7 +50,7 @@ jobs:
         mkdir build 
         cd build
         cmake ..
-        make -j2
+        make -j2 VERBOSE=1
     
     - name: test
       run: |

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -12,7 +12,7 @@ on:
     - README.md
 
 jobs:
-  build:
+  Linux:
     runs-on: ubuntu-latest
     env:
       FC: gfortran-9
@@ -31,7 +31,7 @@ jobs:
         mkdir build 
         cd build
         cmake ..
-        make -j2
+        make -j2 VERBOSE=1
     
     - name: test
       run: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -12,7 +12,7 @@ on:
     - README.md
 
 jobs:
-  macOS-build:
+  MacOS:
     runs-on: macos-latest
     env:
       FC: gfortran-11

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -12,7 +12,7 @@ on:
     - README.md
 
 jobs:
-  build:
+  developer:
     runs-on: ubuntu-latest
     env:
       FC: gfortran-9
@@ -37,7 +37,7 @@ jobs:
         mkdir build 
         cd build
         cmake -DENABLE_DOCS=ON -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address -Wall -Werror" -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address -Wall" -DCMAKE_BUILD_TYPE=Debug ..
-        make -j2
+        make -j2 VERBOSE=1
     
     - name: test
       run: |


### PR DESCRIPTION
Fixes #81 

Now all CI workflows are required to pass before merge to develop.