### PR TITLE
Fixing doxygen warnings / errrors

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -53,4 +53,3 @@ jobs:
         path: |
           g2tmpl/build/*.html
           g2tmpl/build/*.css
-        

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -53,3 +53,4 @@ jobs:
         path: |
           g2tmpl/build/*.html
           g2tmpl/build/*.css
+        

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -976,7 +976,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = @abs_top_srcdir@/docs/sp_user_guide.md
+USE_MDFILE_AS_MAINPAGE = @abs_top_srcdir@/docs/user_guide.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,6 +1,6 @@
 @mainpage
 
-## Introduction
+# Introduction
 
 This document briefly describes the NCEPLIBS-g2tmpl library.
 
@@ -37,7 +37,7 @@ Where:
                  and 1 for the parameter from the NCEP local table)
 - Mnemonic         grib2_NCEP_mnemonic (locally defined at NCEP). 
 
-## Example
+### Example
 
 An entry of paramter TEMPERATURE in grib2 table 4.2
 
@@ -225,7 +225,7 @@ This file updates “Product Definition Templates” used in Section 4
 This file updates the available parameters in GRIB2 tables.
 * New file as needed (e.g., new compression, new feature, …)
 
-### Documentation for Previous Versions of NCEPLIBS-g2tmpl
+## Documentation for Previous Versions of NCEPLIBS-g2tmpl
 
 * [NCEPLIBS-g2tmpl Version 1.11.0](ver-1.11.0/index.html)
 * [NCEPLIBS-g2tmpl Version 1.10.0](ver-1.10.0/index.html)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -4,7 +4,7 @@
 
 This document briefly describes the NCEPLIBS-g2tmpl library.
 
-## GRIB2 Tables/Templates
+# GRIB2 Tables/Templates
 
 NCO Provides documentation on WMO GRIB2 at
 https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/
@@ -15,9 +15,9 @@ descriptions of each template and code table information. This
 document can be found at https://codes.wmo.int/grib2/_codeflag (PDF
 and MSWord formats are available).
 
-## Editing Parameters in the GRIB2 Tables
+# Editing Parameters in the GRIB2 Tables
 
-### GRIB2 - TABLE 4.2-0-0 PARAMETERS FOR DISCIPLINE 0 CATEGORY 0
+## GRIB2 - TABLE 4.2-0-0 PARAMETERS FOR DISCIPLINE 0 CATEGORY 0
 
 GRIB2 parameter table for all disciplines and categories and parameter. These fields are 
 in order as below:
@@ -37,7 +37,7 @@ Where:
                  and 1 for the parameter from the NCEP local table)
 - Mnemonic         grib2_NCEP_mnemonic (locally defined at NCEP). 
 
-### Example
+## Example
 
 An entry of paramter TEMPERATURE in grib2 table 4.2
 
@@ -74,7 +74,7 @@ The procedures are following:
 </pre>
 4.  run the sort_params_grib2_tbl  manually to write output file which it will be sorted.
 
-## Adding New Generating Process ID or Model ID PDT in GRIB2 tables
+# Adding New Generating Process ID or Model ID PDT in GRIB2 tables
 
 The following variables are often requested by developers: parameters, model id or new
 grid id to add to NCEPGRIB2 tables.  Example:
@@ -159,7 +159,7 @@ Example:
          ==>   The output file is:  params_grib2_tbl_new   file
 5. We will give these two files: params_grib2_tbl_new.text  and params_grib2_tbl_new to developer for testing and UPP (code manager is Wen).
 
-### New Generating Process ID (see Code ON388 Table A) or  Product Definition Template.
+## New Generating Process ID (see Code ON388 Table A) or  Product Definition Template.
 
 (see PDT at https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-0.shtml)
            We need to modify the following files in g2tmpl library:
@@ -178,7 +178,7 @@ https://docs.google.com/document/d/1VK3j0K0CXRxaP7ZW-uJuyGKosVVAuIOkBBIafY2tzW0/
 Wen Meng)
 https://docs.google.com/document/d/1r2BQtAI33S_zCDh6Ko-aFW0kO79MYILspW31Bw4zE60/edit
 
-### Maintaining NCEP WMO GRIB2 DOCUMENTATION and Update GRIB2 library
+## Maintaining NCEP WMO GRIB2 DOCUMENTATION and Update GRIB2 library
 
 The NCEP WMO grib2 document is on NCO RZDM web site:
 https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/ WMO updates


### PR DESCRIPTION
This PR fixes some warnings / errors thrown while building the docs in the developer workflow.

1. Fixed incorrect file name for user guide
2. Fixed levels of headers in user guide