### PR TITLE
added nwc procesing id to on388_tablea and products to table 4.2-1-0

### DIFF
--- a/src/grib2_all_tables_module.F90
+++ b/src/grib2_all_tables_module.F90
@@ -21,6 +21,7 @@
 !> 2023/03/30 | Andrew Benjamin | Added new entires to on388)_tablea
 !> 2024/02/23 | Andrew Benjamin | Added new subcenter to on388)_tablec
 !> 2024/12/20 | Alyson Stahl | Added multiple entries from 2024 WMO updates
+!> 2025/02/14 | Andrew Benjamin | Added new processing ids to on388_tablea
 !>
 !> @author Jun Wang @date 2012/01/25
 module grib2_all_tables_module
@@ -1279,6 +1280,8 @@ module grib2_all_tables_module
   data on388_tablea(125) /gen_proc('urma',118)/
   data on388_tablea(126) /gen_proc('wam',119)/
   data on388_tablea(127) /gen_proc('ccpa',184)/
+  data on388_tablea(128) /gen_proc('fho_nwc',53)/
+  data on388_tablea(129) /gen_proc('ahd_nwc',54)/
 
 contains
   !

--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -24,6 +24,7 @@
    0  20     3   0 AEMFLX
    0  13     0   0 AEROT
    0   2    36   0 AFRWE
+   1   0   196   1 AHD
    0  20    50   0 AIA
    0  18    10   0 AIRCON
   10   0    82   0 AIRDENOC
@@ -472,6 +473,7 @@
    1   0     0   0 FFLDG
    1   0     1   0 FFLDRO
    2   4     6   0 FFMCODE
+   1   0   194   1 FHO
    0   1   228   1 FICEAC
    0   6    21   0 FICE
    0   6   199   1 FICE

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -1140,6 +1140,9 @@
 !  NCEP Local use
    1   0   192   1 BGRUN
    1   0   193   1 SSRUN
+!  New parameters added 02/14/2025
+   1   0   194   1 FHO
+   1   0   196   1 AHD
 !
 ! GRIB2 - TABLE 4.2-1-1 PARAMETERS FOR DISCIPLINE 1 CATEGORY 1
 !


### PR DESCRIPTION
This PR fixes #149, specifically 2 changes for the NWC:

1.) adds FHO and AHD to Table 4.2-0-1 to
- params_grib2_tbl_new.text 
- params_grib2_tbl_new

2.) Adds numbers 53 and 54 as new generating process ids to [ON388-Table A](https://www.nco.ncep.noaa.gov/pmb/docs/on388/tablea.html):

