### PR TITLE
Add hail accumulation and diffuse short-wave radiation flux (clear sky)

### DIFF
--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -316,6 +316,7 @@
    0   0     7   0 DEPR
    1   0    13   0 DEPWSS
   20   1     6   0 DFPRATIO
+   0   4   206   1 DFSWRFLXCS
   10   2     2   0 DICED
    4  10     3   0 DIDXSG
    4   4     2   0 DIFEFLUX
@@ -553,6 +554,7 @@
    1   0     9   0 GWLOWS
    2   0   214   1 GWREC
    1   0     8   0 GWUPS
+   0   1   236   1 HAILAC
    0   1    71   0 HAILMXR
    0  19   198   1 HAILPROB
    0   1    73   0 HAILPR

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -23,7 +23,7 @@
 !                                    new tables: 4.2-2-6
 !                                    4.2-4-5,10 4.2-20-0,1,2,3
 !2024-07-17         A. BENJAMIN      GRIB2 v33.0 update, new parameters
-!
+!2025-05-14         B. BLAKE         Added new parameters
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -321,6 +321,8 @@
    0   1   233   1 SNOWLR
    0   1   234   1 PCPDUR
    0   1   235   1 CLLMR
+!  Added new parameters on 5/14/2025
+   0   1   236   1 HAILAC
    0   1   241   1 TSNOW
    0   1   242   1 RHPW
    0   1   245   1 MAXVIG
@@ -590,6 +592,8 @@
    0   4   203   1 NDDSF
    0   4   204   1 DTRF
    0   4   205   1 UTRF
+!  Added new parameters on 5/14/2025
+   0   4   206   1 DFSWRFLXCS
 !
 ! GRIB2 - TABLE 4.2-0-5 PARAMETERS FOR DISCIPLINE 0 CATEGORY 5
 !


### PR DESCRIPTION
This PR resolves issue #157 

Two products are added to params_grib2_tbl_new and params_grib2_tbl_new.text:

1. Hail accumulation (HAILAC) is added as parameter 236 to [Table 4.2-0-1](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-1.shtml).
2. Diffuse short-wave radiation flux, clear sky (DFSWRFLXCS) is added as parameter 206 to [Table 4.2-0-4](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-4.shtml).

@Hang-Lei-NOAA if these changes could be included in the next g2tmpl release, that would be great - thanks!