### PR TITLE
Add GCAFS, MLGFS, and MLGEFS generating process IDs to ON388 - Table A

### DIFF
--- a/src/grib2_all_tables_module.F90
+++ b/src/grib2_all_tables_module.F90
@@ -23,6 +23,7 @@
 !> 2024/12/20 | Alyson Stahl | Added multiple entries from 2024 WMO updates
 !> 2025/02/14 | Andrew Benjamin | Added new processing ids to on388_tablea
 !> 2025/04/14 | Ben Blake | Added new processing id to on388_tablea
+!> 2025/08/19 | Ben Blake | Added new processing ids to on388_tablea
 !>
 !> @author Jun Wang @date 2012/01/25
 module grib2_all_tables_module
@@ -1287,6 +1288,12 @@ module grib2_all_tables_module
   !   Added new entries in tablea (04/14/2025)
   !
   data on388_tablea(130) /gen_proc('refs',136)/
+  !
+  !   Added new entries in tablea (08/19/2025)
+  !
+  data on388_tablea(131) /gen_proc('gcafs',97)/
+  data on388_tablea(132) /gen_proc('mlgfs',137)/
+  data on388_tablea(133) /gen_proc('mlgefs',138)/
 
 contains
   !


### PR DESCRIPTION
This PR resolves issue #163 

3 new generating process IDs have been requested to be added to [ON388 - Table A](https://www.nco.ncep.noaa.gov/pmb/docs/on388/tablea.html):

Global Chemistry and Aerosol Forecast System (GCAFS) - 97
Machine Learning Global Forecast System (MLGFS) - 137
Machine Learning Global Ensemble Forecast System (MLGEFS) - 138