### PR TITLE
Add FOGLWC to Table 4.2-0-6

### DIFF
--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -492,6 +492,7 @@
    0  19   205   1 FLGHT
    0   7    18   0 FLXRN
   20   1     9   0 FMALVRH
+   0   6   202   1 FOGLWC
    0   6    50   0 FOG
    2   4     4   0 FOSINDX
    0   1    67   0 FPRATE

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -26,6 +26,7 @@
 !2025-05-14         B. BLAKE         Added new parameters
 !2025-06-11         B. BLAKE         Added new parameters
 !2025-08-04         B. BLAKE         Added new parameters
+!2025-09-17         B. BLAKE         Added new parameter
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -696,6 +697,8 @@
    0   6   199   1 FICE
    0   6   200   1 MFLUX
    0   6   201   1 SUNSD
+! Added new parameters on 09/17/2025
+   0   6   202   1 FOGLWC
 !
 ! GRIB2 - TABLE 4.2-0-7 PARAMETERS FOR DISCIPLINE 0 CATEGORY 7
 !


### PR DESCRIPTION
This PR resolves issue #169 

A NCEP local use parameter, FOG (LWC), is added to [Table 4.2-0-6](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-6.shtml) for defining fog intensity in REFS products.