### PR TITLE
Add new parameters - WMO GRIB2 table updates and Fog (LWC)

### DIFF
--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -5,13 +5,16 @@
    0   3    15   0 5WAVH
    0   3   193   1 5WAVH
    0  20   106   0 AACOEF
+  20   5     3   0 AAIRPOLHI
    4  10     4   0 AATRATE
+   0  20   113   0 ABCOEF
    0   2    11   0 ABSD
    4   2     5   0 ABSFRQ
    0   1    18   0 ABSH
    4   2     6   0 ABSRB
    0   2    10   0 ABSV
    0  18     0   0 ACCES
+  20   4    33   0 ACIDRAINHI
    0  18     1   0 ACIOD
    2   0   228   1 ACOND
    0   1   224   1 ACPCPN
@@ -28,6 +31,7 @@
    0  20    50   0 AIA
    0  18    10   0 AIRCON
   10   0    82   0 AIRDENOC
+  20   5     2   0 AIRPOLHI
    2   0   208   1 AKHS
    2   0   209   1 AKMS
   10   2    14   0 ALBDOICE
@@ -73,16 +77,21 @@
    3   1    13   0 ATMDIV
    0  20   101   0 ATMTK
    4  10     7   0 AURELEC
+  20   4    50   0 AVALHI
   20   1     8   0 AVECTNUM
   20   1     7   0 AVHRATIO
    2   3   201   1 AVSFT
   10 191     4   0 BARDSF
    2   3   200   1 BARET
   10   4     7   0 BATHY
+  20   4    14   0 BCHI
+  20   5     8   0 BDLOSSHI
   10   0    44   0 BENINX
+  10   0    99   0 BFI2D
    1   0     5   0 BGRUN
    1   0   192   1 BGRUN
   10   4   194   1 BKENG
+  20   4    34   0 BLIZHI
    0   7     1   0 BLI
    0   7    16   0 BLKRN
    0   2    20   0 BLYDP
@@ -217,6 +226,7 @@
    0   3    37   0 CNTMF
    0   3   209   1 CNVDEMF
    0   3   208   1 CNVDMF
+   0   2    68   0 CNVGUST
    0   0   196   1 CNVHR
    0   1   213   1 CNVMR
    0   3   207   1 CNVUMF
@@ -226,8 +236,11 @@
    2   0   196   1 CNWAT
    0   1   151   0 CNWVMF
    0  20    56   0 COAIA
+  20   5    20   0 COASTEROHI
+  20   4     4   0 COASTFLDHI
    0  20     1   0 COLMD
    2   4    24   0 COMBCO
+  20   5    18   0 COMPSOILHI
    0  20    51   0 CONAIR
    0   7    19   0 CONAPES
    0   1   216   1 CONDP
@@ -238,6 +251,8 @@
    0  19    15   0 CONTT
    0  19    26   0 CONVO
    0  19   222   1 CONVP
+  20   5    17   0 CORALBHI
+   3   1    24   0 COSOLZA
    0 192     6   0 COVMM
    0 192     1   0 COVMZ
    0   2   205   1 COVMZ
@@ -281,6 +296,7 @@
    0   1    55   0 CSRWE
    0   5   195   1 CSULF
    0   4   198   1 CSUSF
+  10   0   100   0 CTCORR
    3   1     3   0 CTOPHQI
    3   1     2   0 CTOPH
    3   2     2   0 CTOPRES
@@ -291,6 +307,7 @@
    0  19   239   1 CWASP
    0   1   149   0 CWATERMR
    0   6     6   0 CWAT
+  20   4    40   0 CWAVEHI
    0   7   195   1 CWDI
    0   6    15   0 CWORK
    0   6   193   1 CWORK
@@ -299,6 +316,7 @@
    0   1   166   0 CWVF
    0  19    41   0 DBHEIGHT
   10   4   195   1 DBSS
+  20   4     1   0 DBURSTHI
    0   7   203   1 DCAPE
    2   4    33   0 DDLMC
    0  20    12   0 DDMFLX
@@ -309,13 +327,18 @@
    2   4    35   0 DDWMC
    2   0    30   0 DECFC
    0   2    61   0 DEC
+  20   5     9   0 DEFORESTHI
    0   3    14   0 DENALT
    0   3    10   0 DEN
    0  18    19   0 DEPACTA
    0  18    20   0 DEPACTE
+  20   4    30   0 DEPRESHI
    0   0     7   0 DEPR
    1   0    13   0 DEPWSS
+  20   4    53   0 DERECHOHI
+  20   5    14   0 DESERTHI
   20   1     6   0 DFPRATIO
+   0   4    63   0 DFSWRFLXCS
    0   4   206   1 DFSWRFLXCS
   10   2     2   0 DICED
    4  10     3   0 DIDXSG
@@ -347,12 +370,14 @@
    0   5     3   0 DLWRF
    0   5   192   1 DLWRF
    0   3    28   0 DMFLX
+   0   4    62   0 DNSWRFLXCS
    0   4    54   0 DNSWRFLX
    0   1   123   0 DPTYPE
    0   0     6   0 DPT
    2   0    43   0 DRAINDIR
    2   4    13   0 DRFACT
    2   4     8   0 DRTCODE
+  20   4    35   0 DRTHI
    0  18    12   0 DRYDEP
    0  19   237   1 DRYTPROB
    4   7     2   0 DSKDAY
@@ -362,9 +387,13 @@
   10   3     1   0 DSLM
   10 191     3   0 DSLOBSO
    0 191     3   0 DSLOBS
+  20   4    15   0 DSTMHI
    0   4    52   0 DSWRFCS
+  10   2    31   0 DSWRFICE
    0   4    61   0 DSWRFLXCS
    0   4    13   0 DSWRFLX
+  10   4    58   0 DSWRFSEA
+  10   3    22   0 DSWRFSS
    0   4     7   0 DSWRF
    0   4   192   1 DSWRF
    0   2    60   0 DTC
@@ -375,6 +404,7 @@
   10   3     4   0 DWHFLUX
    0   4    12   0 DWUVR
    0   2     9   0 DZDT
+  20   4    41   0 DZUDHI
    0   7   207   1 E3KH
    0  21    22   0 EADYGR
    3   2    11   0 EAODR
@@ -391,7 +421,9 @@
   10   4    23   0 EASTWVEL
    3   5     5   0 EBSDSSTS
    3   5     4   0 EBSSTSTD
+  20   0    12   0 ECF
    2   0    61   0 ECORFLUX
+  20   4    31   0 ECPRESHI
    4  10     6   0 EDISSTIX
    0  19    30   0 EDPARM
    0   1   138   0 EFARCICE
@@ -413,6 +445,7 @@
    0   1   132   0 EFRSNOW
    0   3   222   1 EFSH
   10   0    89   0 EFWS
+  20   0    11   0 EHF
    0   7     9   0 EHLX
    2   0   237   1 EIWATER
    4   2     1   0 ELCDEN
@@ -435,6 +468,7 @@
    1   0     3   0 ESCT
    0   2   233   1 ESHR
    0   7   205   1 ESP
+  20   4     5   0 ESTFLDHI
    3   1     0   0 ESTP
    3   1     4   0 ESTUGRD
    3   1     5   0 ESTVGRD
@@ -445,6 +479,7 @@
    4   3     4   0 ETOT
   10   3   193   1 ETSRG
    0   2    38   0 ETSS
+  20   5    24   0 EUTROPHI
    4   6     3   0 EUVIRR
    4   8     1   0 EUVRAD
    2   0    39   0 EVAPTRAT
@@ -472,6 +507,7 @@
    2   4    11   0 FDSRTE
    2   4    34   0 FDWMC
    1   0     0   0 FFLDG
+  20   4     6   0 FFLDHI
    1   0     1   0 FFLDRO
    2   4     6   0 FFMCODE
    1   0   194   1 FHO
@@ -490,9 +526,15 @@
    1   0    18   0 FLDPOW
    1   0    12   0 FLDPSW
    0  19   205   1 FLGHT
+  20   4     7   0 FLUVFLDHI
    0   7    18   0 FLXRN
   20   1     9   0 FMALVRH
+  20   4    16   0 FOGHI
+   0   6   202   1 FOGLWC
    0   6    50   0 FOG
+  20   5    10   0 FORESTDECHI
+  20   5    11   0 FORESTDISHI
+  20   5    12   0 FORESTINVHI
    2   4     4   0 FOSINDX
    0   1    67   0 FPRATE
    0   6    32   0 FRACCC
@@ -505,11 +547,14 @@
   10   0    17   0 FRICVW
    0   2    30   0 FRICV
    0   2   197   1 FRICV
+  20   4    43   0 FROSTHI
    0   1   227   1 FROZR
    2   3    24   0 FRSTINX
   10   0    64   0 FRWWTSW
   10   2    29   0 FRZDATE
+  20   4    42   0 FRZHI
   10   2    27   0 FRZMLTPOT
+  20   4    44   0 FRZRHI
    0   1   225   1 FRZR
   10   3   204   1 FRZSPR
    0   1   121   0 FSNOWC
@@ -520,6 +565,7 @@
   10   4    30   0 FWFSW
    2   4     5   0 FWINX
    0   1    95   0 FZPRATE
+  20   4    54   0 GALEHI
    0  18    25   0 GAMDOSER
    0   3    33   0 GAMSL
    0  18     3   0 GDCES
@@ -529,13 +575,17 @@
    0 191     2   0 GEOLON
    0   2    43   0 GEOWD
    0   2    44   0 GEOWS
+  20   4     8   0 GFLDHI
    2   0    10   0 GFLUX
    2   0   193   1 GFLUX
+  20   4    46   0 GFROSTHI
    0   3    34   0 GHARGRD
    2   5     0   0 GLACCOV
    2   5     1   0 GLACTMP
+  20   4    45   0 GLAZEHI
    0  19    47   0 GLIRRTS
   20   0     3   0 GLOBETMP
+  20   4    13   0 GLOFLDHI
   10   0    98   0 GODAPEAK
    0   3     9   0 GPA
    0   1    75   0 GPRATE
@@ -555,6 +605,7 @@
    2   0   214   1 GWREC
    1   0     8   0 GWUPS
    0   1   236   1 HAILAC
+  20   4    36   0 HAILHI
    0   1    71   0 HAILMXR
    0  19   198   1 HAILPROB
    0   1    73   0 HAILPR
@@ -570,16 +621,21 @@
    4   8     6   0 HELCOR
   10   3    18   0 HFLUXCOR
    2   0    24   0 HFLUX
+   2   4    40   0 HGTINJ
    0  20    62   0 HGTMD
    0   3   211   1 HGTN
+   2   4    41   0 HGTPLUMEB
+   2   4    42   0 HGTPLUMET
    0   3   203   1 HGTX
    0   3   204   1 HGTY
    0   3     5   0 HGT
+  20   5     1   0 HHAIRPOLHI
    0  19    32   0 HIFREL
    2   4     2   0 HINDEX
    2   0    54   0 HIVEGCOV
    0   7     8   0 HLCY
    0  18    16   0 HMXACON
+   2   7     0   0 HNETFLUX
    0   3    18   0 HPBL
    0   3   196   1 HPBL
    4   2     8   0 HPRIMF
@@ -590,11 +646,14 @@
   10   0     3   0 HTSGW
   20   0     4   0 HUMIDX
    0 191     5   0 HURTSV
+  20   4    47   0 HWAVEHI
    0   3    44   0 HWBT
+  20   4    17   0 HZHI
    0   3     3   0 ICAHT
    1   2     7   0 ICECIL
   10   2     0   0 ICEC
   10   2     7   0 ICED
+  20   4    25   0 ICEFLOWHI
   10   2    19   0 ICEFTHCK
   10   2     6   0 ICEG
   10   2    21   0 ICEMPD
@@ -604,11 +663,13 @@
    0   1   127   0 ICEP
    0  19    27   0 ICESC
    0  19    37   0 ICESEV
+  20   4    37   0 ICESTMHI
    2   3    29   0 ICETEMP
    1   2     6   0 ICETIL
   10   2     1   0 ICETK
   10   2     8   0 ICETMP
    0  19     6   0 ICIB
+  20   4    48   0 ICINGHI
    0  19    20   0 ICIP
    0  19     5   0 ICIT
    0  19     7   0 ICI
@@ -618,6 +679,7 @@
    1   2     5   0 ICTKIL
    2   0   207   1 ICWAT
    2   4    18   0 IGNCOMP
+  20   4     9   0 IJFLDHI
    0   1    20   0 ILIQW
   10   0    27   0 IMFTSW
   10   0    26   0 IMFWW
@@ -646,6 +708,7 @@
    2   0    55   0 LAILO
    0   7   198   1 LAI
    2   0   234   1 LAKEFRC
+  20   5     4   0 LANDDEGHI
    2   0   233   1 LANDFRC
    1   2     8   0 LANDIL
    2   0   218   1 LANDN
@@ -661,11 +724,14 @@
   10   3   203   1 LCH
    1   2    15   0 LDEPTH
    2   0    28   0 LEAINX
+   2   4    38   0 LFMCHV
+   2   4    37   0 LFMCLV
    2   4    31   0 LFMC
    0   7    10   0 LFTX
    0   7   192   1 LFTX
    0   0    30   0 LHFLXE
    0   0    31   0 LHFLXS
+   2   7     1   0 LHTFLUX
    0   0    10   0 LHTFL
    0   1   229   1 LICEAC
    0  13   195   1 LIPMF
@@ -693,6 +759,7 @@
    0   1    59   0 LSSRATE
    0   1    56   0 LSSRWE
    0   1    47   0 LSWP
+  20   4     2   0 LTNGHI
    0  17     0   0 LTNGSD
    0  17   192   1 LTNG
    0  17     1   0 LTPINX
@@ -704,6 +771,7 @@
   20   1     1   0 MACPRATE
   20   1     0   0 MALACASE
   20   1     4   0 MALAIMM
+  20   5    15   0 MANLOSSHI
    4   8     7   0 MASK
    0   6    38   0 MASSDCD
    0   6    39   0 MASSDCI
@@ -737,6 +805,7 @@
   10   0    74   0 MDTSWEL
   10   0    75   0 MDWWAVE
    3   2    30   0 MEACST
+   2   4    39   0 MEANHGTINJ
   20   0     1   0 MEANRTMP
    0  19    44   0 MEANVGRTL
    0   6   200   1 MFLUX
@@ -748,6 +817,7 @@
    0  19     3   0 MIXHT
    0  19   204   1 MIXLY
    0   1     2   0 MIXR
+  10   4    52   0 MLD
    0   7   212   1 MLFC
   10   2    28   0 MLTDATE
    0 191   195   1 MLYNO
@@ -772,6 +842,7 @@
    2   0     7   0 MTERH
   10   4     1   0 MTHA
   10   4     0   0 MTHD
+  20   4    51   0 MUDFLOWHI
   10   2    11   0 MVCICEP
   10   0    53   0 MWDFSWEL
   10   0    41   0 MWDIRW
@@ -794,6 +865,7 @@
    0  19   213   1 NBSALB
    0   6    29   0 NCCICE
    0   1   207   1 NCIP
+  10   4    53   0 NCOMPWVEL
    0   6    28   0 NCONCD
    0   1     9   0 NCPCP
    0   6    31   0 NDCICE
@@ -854,6 +926,7 @@
    0   2    40   0 NWTPARM
    0  14     1   0 O3MR
    0  14   192   1 O3MR
+  20   4    21   0 OAHI
   10   4   197   1 OHC
    0   2   215   1 OMGALF
   10   1   192   1 OMLU
@@ -903,6 +976,8 @@
    0   1    41   0 PEVPR
    0   1   200   1 PEVPR
   20   1     2   0 PFEIRATE
+  20   4    10   0 PFLDHI
+  20   5    21   0 PFLOSSHI
    4   5     1   0 PHASE
    0   4    60   0 PHOARFCS
    0   4    10   0 PHOTAR
@@ -916,6 +991,7 @@
   10   0    23   0 PMAXWH
    0  13   192   1 PMTC
    0  13   193   1 PMTF
+  20   4    18   0 POLAIRHI
   20   2     0   0 POPDEN
    1   1     2   0 POP
    2   3     9   0 POROS
@@ -935,7 +1011,9 @@
    0   1   240   1 PRATE10MIN
    0   1   238   1 PRATE1MIN
    0   1   239   1 PRATE5MIN
+   0  16     6   0 PRATEF
    0   1     7   0 PRATE
+   0  15    17   0 PRATE
    4   0     4   0 PRATMP
    0  15     5   0 PREC
    0   3    13   0 PRESALT
@@ -988,6 +1066,7 @@
    2   0    19   0 RCT
    2   0   203   1 RCT
    1   2    16   0 RDEPTH
+   0  15    19   0 RDQF
    2   0   206   1 RDRIP
    0  15     6   0 RDSP1
    0  15     7   0 RDSP2
@@ -1032,28 +1111,36 @@
    0   7   194   1 RI
    2   3     6   0 RLYRS
    2   3   193   1 RLYRS
+   0   7    22   0 RMOL
    2   6     1   0 ROADCOVER
    4  10     2   0 ROTIDX
    0   1    65   0 RPRATE
+   0  15    18   0 RQI
+  20   4    52   0 RSLIDEHI
    2   0    16   0 RSMIN
    2   0   200   1 RSMIN
    1   0     2   0 RSSC
    0 191   194   1 RTSEC
+  20   5     6   0 RUNOFFHI
   10   3   206   1 RUNUP
    1   2    21   0 RVERAR
    1   2    20   0 RVERFR
    1   0    17   0 RVEROW
    1   0    11   0 RVERSW
   10   0    80   0 RWAVEAFW
+  20   4    22   0 RWAVEHI
    0   1    24   0 RWMR
    0  18    14   0 SACON
    0  20   100   0 SADEN
+  20   4    19   0 SAHZHI
    0  19    19   0 SALBD
    3   0     1   0 SALBEDO
   10   3    21   0 SALINITY
   10   4   193   1 SALIN
+  20   5     7   0 SALTHI
    1   2    12   0 SALTIL
   10   4     3   0 SALTY
+  20   5    22   0 SAMINHI
    0   1     5   0 SATD
    2   3    17   0 SATOSM
    3 192     4   0 SBC123
@@ -1135,6 +1222,7 @@
    3   1    99   0 SDMPEMRR
    0   3    20   0 SDSGSO
    0   1    60   0 SDWE
+  10   4    57   0 SEAAGE
   10   4    48   0 SEACMMT
   10   4    44   0 SEACMVT
   10   4    50   0 SEACPSALT
@@ -1144,12 +1232,15 @@
   10   4    46   0 SEAMMT
   10   4    42   0 SEAMVT
   10   3    12   0 SEASFLUX
+  10   4    56   0 SEAUMT
+  10   4    55   0 SEAUVT
   10   4    47   0 SEAZMT
   10   4    43   0 SEAZVT
    0  20    11   0 SEDMFLX
    1   2     3   0 SEDTK
    1   2     4   0 SEDTMP
    0  19    39   0 SEEINDEX
+  20   4    26   0 SEICHEHI
   10   3   207   1 SETUP
    0   1    62   0 SEVAP
   10   0    86   0 SEVWAVE
@@ -1184,11 +1275,16 @@
    0  19   201   1 SHAILPRO
    0   1   214   1 SHAMR
    2   3    26   0 SHFLX
+   2   7     2   0 SHTFLUX
    0   0    11   0 SHTFL
    0   1   108   0 SHTPRM
+ 191   0     4   0 SHUM
    0   7    13   0 SHWINX
+  10   2    30   0 SICEBM
   10   2     3   0 SICED
   10   2    17   0 SICEHC
+  20   4    24   0 SICEHI
+  10   2    26   0 SICESAL
   10   2    15   0 SICEVOL
    4   8     8   0 SICFL
   10   2    23   0 SIFTP
@@ -1198,6 +1294,7 @@
    4   9     0   0 SIGPED
    0   7   211   1 SIGT
    0  19   217   1 SIPD
+ 191   0     2   0 SKEB
    2   0    50   0 SKINRC
    0   0    17   0 SKINT
    3   5     1   0 SKSSTMP
@@ -1206,20 +1303,24 @@
    0  19    23   0 SLDP
    3   0     4   0 SLFTI
    0  17     5   0 SLNGPIDX
+  20   5    23   0 SLRHI
   10   3   202   1 SLTFL
    2   3   194   1 SLTYP
    0   6    34   0 SLWTC
    2   3     8   0 SMDRY
    2   3   196   1 SMDRY
+  20   4    11   0 SMFLDHI
    0   1   113   0 SMLWGMA
    0   1   110   0 SMLWHMA
    0   1   116   0 SMLWSMA
+  20   4    20   0 SMOKEHI
    2   0    41   0 SMRATE
    2   3     7   0 SMREF
    2   3   195   1 SMREF
    0  22     5   0 SMRI
    0  19    18   0 SNFALB
    0  19   193   1 SNFALB
+   0  20    82   0 SNKMFLX
    0   1    25   0 SNMR
    0   1    17   0 SNOAG
    0   1    14   0 SNOC
@@ -1233,9 +1334,11 @@
    0   1    42   0 SNOWC
    0   1   201   1 SNOWC
    0   1   148   0 SNOWERAT
+  20   4    38   0 SNOWHI
    0   1   233   1 SNOWLR
    0  19    40   0 SNOWLVL
    0  19   236   1 SNOWLVL
+  20   4    39   0 SNOWSTMHI
    2   3    28   0 SNOWTMP
   10   2    13   0 SNOWTSI
    0   1   222   1 SNOWT
@@ -1244,7 +1347,9 @@
   10   2    18   0 SNSIHC
   10   2    16   0 SNVOLSI
    2   3    25   0 SNWDEB
+  20   5     5   0 SOILDEGHI
    2   3    27   0 SOILDEP
+  20   5    19   0 SOILEROHI
    2   3    21   0 SOILICE
    2   3     5   0 SOILL
    2   3   192   1 SOILL
@@ -1270,14 +1375,18 @@
    0   1   103   0 SPNCH
    0   1   100   0 SPNCR
    0   1   101   0 SPNCS
+ 191   0     0   0 SPPT
+ 191   0     1   0 SPP
    0   1    66   0 SPRATE
    2   4    16   0 SPRDCOMP
    4   2     7   0 SPRDF
   20   3     4   0 SPVPCAP
   20   3     5   0 SPVPPROD
    3   0     3   0 SPWAT
+  20   4    55   0 SQLNHI
    3   0     0   0 SRAD
    0   1    85   0 SRAINC
+   0  20    83   0 SRCMFLX
    0  19   194   1 SRCONO
    3 192    46   0 SRFAGR1
    3 192    47   0 SRFAGR2
@@ -1293,6 +1402,7 @@
    0   3    22   0 SSGSO
   10   3    19   0 SSHGTPARM
   10   3   195   1 SSHG
+   0   7    21   0 SSI
    3   5     2   0 SSKSSTMP
    3 192    86   0 SSMS1712
    3 192    87   0 SSMS1713
@@ -1306,24 +1416,30 @@
    1   0     6   0 SSRUN
    1   0   193   1 SSRUN
   10   3   200   1 SSST
+  20   4    56   0 SSTMHI
    3   0     6   0 SSTMP
    2   0   211   1 SSTOR
   10   3   199   1 SSTT
    0   6    35   0 SSWTC
+ 191   0     3   0 STC
   20   0     7   0 STDEFTMP
   10   3    11   0 STERCSSH
   10   0    96   0 STMCREST
+  20   4    28   0 STMTIDEHI
   10   0    97   0 STMWAVE
    0  19   200   1 STORPROB
    0   7   208   1 STPC
    0   2     4   0 STRM
    0   1    87   0 STRPRATE
+ 191   0     5   0 STTP
    2   0    52   0 SUBSRATE
+  20   4    32   0 SUBTCPRESHI
    0   6    51   0 SUNFRAC
    0   6    33   0 SUNSD
    0   6   201   1 SUNSD
    0   6    24   0 SUNS
    2   0    51   0 SURFRATE
+  20   4    27   0 SURGEHI
   10   3   192   1 SURGE
    0  19   220   1 SVRTS
   10   3   208   1 SWASH
@@ -1335,10 +1451,12 @@
   10   0     8   0 SWELL
    1   0     4   0 SWEPON
    2   3    30   0 SWET
+  20   4    12   0 SWFLDHI
   10   0    47   0 SWHFSWEL
    0   4   197   1 SWHR
   10   0    48   0 SWHSSWEL
   10   0    49   0 SWHTSWEL
+  20   4    23   0 SWIHI
    0  19   202   1 SWINDPRO
    0  22     4   0 SWI
   10   0     9   0 SWPER
@@ -1377,6 +1495,7 @@
    0   6    18   0 TCOLWO
    0   1    69   0 TCOLW
    0   6   196   1 TCOLW
+  10   4    54   0 TCOMPWVEL
    0   6    17   0 TCONDO
    0   1    21   0 TCOND
    0   6   195   1 TCOND
@@ -1390,12 +1509,14 @@
   10   3   248   1 TCSRG80
   10   3   249   1 TCSRG90
    0   1    51   0 TCWAT
+  20   4    57   0 TCWINDHI
    0   0    20   0 TDCHT
    0   2    31   0 TDCMOM
   10   0    94   0 TDMCREST
   10   0    95   0 TDMWAVE
    0 191     7   0 TDTSV
    2   0    36   0 TFRCT
+  20   4    49   0 THAWHI
   10   3     9   0 THERCSSH
    0   0   197   1 THFLX
    0   3    12   0 THICK
@@ -1424,6 +1545,7 @@
    0   2   228   1 TOA50
    0   2   229   1 TOD50
    0   2   230   1 TOD90
+  20   4    59   0 TORHI
    0  19   197   1 TORPROB
    0   7     4   0 TOTALX
    0   1    80   0 TOTCON
@@ -1454,8 +1576,11 @@
    0   1    57   0 TSRATE
    0   1    53   0 TSRWE
    0  19   203   1 TSTMC
+  20   4     3   0 TSTMHI
    0  19     2   0 TSTM
    0 191     6   0 TSTSV
+  20   4    29   0 TSUNAMIHI
+  20   4    58   0 TSWINDHI
    0   0    19   0 TTCHT
    0   0   198   1 TTDIA
   10   4     2   0 TTHDP
@@ -1467,6 +1592,7 @@
    0   0    24   0 TTSWRCS
    0   0    22   0 TTSWR
    0  19     9   0 TURBB
+   0   2    69   0 TURBGUST
    0  19     8   0 TURBT
    0  19    10   0 TURB
    0   1    49   0 TWATP
@@ -1527,6 +1653,8 @@
    0   4    58   0 UVALBDIRI
    0   4    56   0 UVALBDIR
    0   4    59   0 UVBDIRV
+  20   0    10   0 UVBEDCS
+  20   0     9   0 UVBED
    0   4    50   0 UVIUCS
    0   4    51   0 UVI
    0   7   196   1 UVI
@@ -1568,6 +1696,7 @@
    0  19    35   0 VISBSN
    0  19    34   0 VISIFOG
    0  19    33   0 VISLFOG
+   0  19    51   0 VISPCP
    0  19     0   0 VIS
    0   1    92   0 VKMFLX
    0  20    52   0 VMXR
@@ -1598,6 +1727,7 @@
   10   0    22   0 VSSD
    0   2    28   0 VSTM
    0   2   195   1 VSTM
+   0  20    84   0 VTCOLMIXR
    4   2     4   0 VTEC
    0   0     1   0 VTMP
    0   2    15   0 VUCSH
@@ -1647,8 +1777,10 @@
    2   0    45   0 WETCOV
    0  18    11   0 WETDEP
    0   0   206   1 WETGLBT
+  20   5    16   0 WETLOSSHI
    2   0    46   0 WETTYPE
    0  20    75   0 WFIREFLX
+  20   5    13   0 WFIREHI
    2   4    26   0 WFIREPOT
    1   2     2   0 WFRACT
   10   0    59   0 WFWFSWEL
@@ -1659,6 +1791,7 @@
    2   0    26   0 WILT
    2   0   201   1 WILT
    0   2    33   0 WINDF
+  20   4    60   0 WINDHI
   20   3     2   0 WINDPCAP
   20   3     3   0 WINDPPROD
    0  19   199   1 WINDPROB
@@ -1673,6 +1806,8 @@
    2   0    42   0 WRDRATE
    2   0    33   0 WROD
   10   0   192   1 WSTP
+  10   0   101   0 WSTRICEX
+  10   0   102   0 WSTRICEY
   10   0    18   0 WSTR
    0   2   214   1 WTEND
   10   4   192   1 WTMPC

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -26,6 +26,10 @@
 !2025-05-14         B. BLAKE         Added new parameters
 !2025-06-11         B. BLAKE         Added new parameters
 !2025-08-04         B. BLAKE         Added new parameters
+!2025-09-17         B. BLAKE         Added new parameter
+!2025-10-01         B. BLAKE         Added new parameters, and
+!                                    new tables 4.2-2-7,4.2-20-4,
+!                                    4.2-20-5,4.2-191-0
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -410,6 +414,9 @@
    0   2    65   0 NRTHTSSOD
    0   2    66   0 EASTTSSSR
    0   2    67   0 NRTHTSSSR
+!  Added new parameters on 10/1/2025
+   0   2    68   0 CNVGUST
+   0   2    69   0 TURBGUST
 !  NCEP Local use
    0   2   192   1 VWSH
    0   2   193   1 MFLX
@@ -585,6 +592,9 @@
    0   4    59   0 UVBDIRV
    0   4    60   0 PHOARFCS
    0   4    61   0 DSWRFLXCS
+!  Added new parameters on 10/1/2025
+   0   4    62   0 DNSWRFLXCS
+   0   4    63   0 DFSWRFLXCS
 !  NCEP Local use
    0   4   192   1 DSWRF
    0   4   193   1 USWRF
@@ -696,6 +706,8 @@
    0   6   199   1 FICE
    0   6   200   1 MFLUX
    0   6   201   1 SUNSD
+! Added new parameter on 9/17/2025
+   0   6   202   1 FOGLWC
 !
 ! GRIB2 - TABLE 4.2-0-7 PARAMETERS FOR DISCIPLINE 0 CATEGORY 7
 !
@@ -722,6 +734,9 @@
    0   7    19   0 CONAPES
 !  Added new parameter 11/2/2023
    0   7    20   0 TIIDEX
+!  Added new parameters on 10/1/2025
+   0   7    21   0 SSI
+   0   7    22   0 RMOL
 !  NCEP Local use
    0   7   192   1 LFTX
    0   7   193   1 4LFTX
@@ -799,6 +814,11 @@
 !  Added more parameters in 8/26/2015
    0  15    15   0 HSR
    0  15    16   0 HSRHT
+!  Added new parameters on 10/1/2025
+   0  15    17   0 PRATE
+   0  15    18   0 RQI
+   0  15    19   0 RDQF
+!  NCEP Local use
 !  Added new parameters on 6/11/2025
    0  15   192   1 RADARVIL
 !
@@ -810,6 +830,8 @@
    0  16     3   0 RETOP
    0  16     4   0 REFD
    0  16     5   0 REFC
+!  Added new parameters on 10/1/2025
+   0  16     6   0 PRATEF
 !  NCEP Local use
    0  16   192   1 REFZR
    0  16   193   1 REFZI
@@ -927,6 +949,8 @@
    0  19    48   0 PCONTT
    0  19    49   0 PCONTB
    0  19    50   0 CITEDR
+!  Added new parameters on 10/1/2025
+   0  19    51   0 VISPCP
 !  NCEP Local use
    0  19   192   1 MXSALB
    0  19   193   1 SNFALB
@@ -1030,6 +1054,10 @@
    0  20    79   0 CNMF
    0  20    80   0 CDIVMF
    0  20    81   0 CNETS 
+!  Added new parameters on 10/1/2025
+   0  20    82   0 SNKMFLX
+   0  20    83   0 SRCMFLX
+   0  20    84   0 VTCOLMIXR
 !
    0  20   100   0 SADEN
    0  20   101   0 ATMTK
@@ -1044,6 +1072,8 @@
    0  20   110   0 ALEGRD
    0  20   111   0 ANGSTEXP
    0  20   112   0 SCTAOTK
+!  Added new parameters on 10/1/2025
+   0  20   113   0 ABCOEF
 !
 ! GRIB2 - TABLE 4.2-0-21 PARAMETERS FOR DISCIPLINE 0 CATEGORY 21
 !
@@ -1430,6 +1460,13 @@
    2   4    34   0 FDWMC
    2   4    35   0 DDWMC
    2   4    36   0 FRADPOW
+!  Added new parameters on 10/1/2025
+   2   4    37   0 LFMCLV
+   2   4    38   0 LFMCHV
+   2   4    39   0 MEANHGTINJ
+   2   4    40   0 HGTINJ
+   2   4    41   0 HGTPLUMEB
+   2   4    42   0 HGTPLUMET
 !
 !  Added new Discipline 2 category 5 in 8/26/2015
 !
@@ -1451,6 +1488,12 @@
    2   6     6   0 DDROOF
    2   6     7   0 DIOWALL
    2   6     8   0 DDROAD
+!                                    
+! GRIB2 - TABLE 4.2-2-7 PARAMETERS FOR DISCIPLINE 2 CATEGORY 7
+!
+   2   7     0   0 HNETFLUX
+   2   7     1   0 LHTFLUX
+   2   7     2   0 SHTFLUX
 !
 ! GRIB2 - TABLE 4.2-3-0 PARAMETERS FOR DISCIPLINE 3 CATEGORY 0
 !
@@ -1491,6 +1534,8 @@
    3   1    21   0 AOT08
    3   1    22   0 AOT16
    3   1    23   0 ANGCOE
+!  Added new parameters on 10/1/2025
+   3   1    24   0 COSOLZA
 !
 !  Added more parameters in 2/28/2017
    3   1    27   0 BRFLF
@@ -1885,6 +1930,11 @@
   10   0    97   0 STMWAVE
 !  New parameters added 07/17/2024
   10   0    98   0 GODAPEAK
+! Added new parameters on 10/1/2025
+  10   0    99   0 BFI2D
+  10   0   100   0 CTCORR
+  10   0   101   0 WSTRICEX
+  10   0   102   0 WSTRICEY
 !  NCEP Local use
   10   0   192   1 WSTP
 !  Added parameter in 8/26/2015
@@ -1935,13 +1985,18 @@
   10   2    21   0 ICEMPD
   10   2    22   0 ICEMPV
   10   2    23   0 SIFTP
-! Added new parameters 12/15/2023
+!  Added new parameters 12/15/2023
   10   2    24   0 XICE
   10   2    25   0 YICE
-!
+!  Added new parameters on 10/1/2025
+  10   2    26   0 SICESAL
+!  Added new parameters 12/15/2023
   10   2    27   0 FRZMLTPOT
   10   2    28   0 MLTDATE
   10   2    29   0 FRZDATE
+!  Added new parameters on 10/1/2025
+  10   2    30   0 SICEBM
+  10   2    31   0 DSWRFICE
 !
 ! GRIB2 - TABLE 4.2-10-3 PARAMETERS FOR DISCIPLINE 10 CATEGORY 3
 !
@@ -1968,8 +2023,10 @@
   10   3    18   0 HFLUXCOR
   10   3    19   0 SSHGTPARM
   10   3    20   0 DSLIBARCOR
-! Added new parameter 12/15/2023
+!  Added new parameter 12/15/2023
   10   3    21   0 SALINITY
+!  Added new parameters on 10/1/2025
+  10   3    22   0 DSWRFSS
 !  NCEP Local use
   10   3   192   1 SURGE
   10   3   193   1 ETSRG
@@ -2063,6 +2120,14 @@
   10   4    49   0 SEACZMT
   10   4    50   0 SEACPSALT
   10   4    51   0 SEACSALT
+!  Added new parameters on 10/1/2025
+  10   4    52   0 MLD
+  10   4    53   0 NCOMPWVEL
+  10   4    54   0 TCOMPWVEL
+  10   4    55   0 SEAUVT
+  10   4    56   0 SEAUMT
+  10   4    57   0 SEAAGE
+  10   4    58   0 DSWRFSEA
 !  NCEP Local use
   10   4   192   1 WTMPC
   10   4   193   1 SALIN
@@ -2092,6 +2157,11 @@
   20   0     6   0 NOREFTMP
   20   0     7   0 STDEFTMP
   20   0     8   0 PEQUTMP
+!  Added new parameters on 10/1/2025
+  20   0     9   0 UVBED
+  20   0    10   0 UVBEDCS
+  20   0    11   0 EHF
+  20   0    12   0 ECF
 !
 ! GRIB2 - TABLE 4.2-20-1 PARAMETERS FOR DISCIPLINE 20 CATEGORY 1
 !
@@ -2122,3 +2192,102 @@
   20   3     7   0 SNPVPPROD
   20   3     8   0 CSPPCAP
   20   3     9   0 CSPPROD
+!
+! GRIB2 - TABLE 4.2-20-4 PARAMETERS FOR DISCIPLINE 20 CATEGORY 4
+!
+  20   4     1   0 DBURSTHI
+  20   4     2   0 LTNGHI
+  20   4     3   0 TSTMHI
+  20   4     4   0 COASTFLDHI
+  20   4     5   0 ESTFLDHI
+  20   4     6   0 FFLDHI
+  20   4     7   0 FLUVFLDHI
+  20   4     8   0 GFLDHI
+  20   4     9   0 IJFLDHI
+  20   4    10   0 PFLDHI
+  20   4    11   0 SMFLDHI
+  20   4    12   0 SWFLDHI
+  20   4    13   0 GLOFLDHI
+  20   4    14   0 BCHI
+  20   4    15   0 DSTMHI
+  20   4    16   0 FOGHI
+  20   4    17   0 HZHI
+  20   4    18   0 POLAIRHI
+  20   4    19   0 SAHZHI
+  20   4    20   0 SMOKEHI
+  20   4    21   0 OAHI
+  20   4    22   0 RWAVEHI
+  20   4    23   0 SWIHI
+  20   4    24   0 SICEHI
+  20   4    25   0 ICEFLOWHI
+  20   4    26   0 SEICHEHI
+  20   4    27   0 SURGEHI
+  20   4    28   0 STMTIDEHI
+  20   4    29   0 TSUNAMIHI
+  20   4    30   0 DEPRESHI
+  20   4    31   0 ECPRESHI
+  20   4    32   0 SUBTCPRESHI
+  20   4    33   0 ACIDRAINHI
+  20   4    34   0 BLIZHI
+  20   4    35   0 DRTHI
+  20   4    36   0 HAILHI
+  20   4    37   0 ICESTMHI
+  20   4    38   0 SNOWHI
+  20   4    39   0 SNOWSTMHI
+  20   4    40   0 CWAVEHI
+  20   4    41   0 DZUDHI
+  20   4    42   0 FRZHI
+  20   4    43   0 FROSTHI
+  20   4    44   0 FRZRHI
+  20   4    45   0 GLAZEHI
+  20   4    46   0 GFROSTHI
+  20   4    47   0 HWAVEHI
+  20   4    48   0 ICINGHI
+  20   4    49   0 THAWHI
+  20   4    50   0 AVALHI
+  20   4    51   0 MUDFLOWHI
+  20   4    52   0 RSLIDEHI
+  20   4    53   0 DERECHOHI
+  20   4    54   0 GALEHI
+  20   4    55   0 SQLNHI
+  20   4    56   0 SSTMHI
+  20   4    57   0 TCWINDHI
+  20   4    58   0 TSWINDHI
+  20   4    59   0 TORHI
+  20   4    60   0 WINDHI
+!
+! GRIB2 - TABLE 4.2-20-5 PARAMETERS FOR DISCIPLINE 20 CATEGORY 5
+!
+  20   5     1   0 HHAIRPOLHI
+  20   5     2   0 AIRPOLHI
+  20   5     3   0 AAIRPOLHI
+  20   5     4   0 LANDDEGHI
+  20   5     5   0 SOILDEGHI
+  20   5     6   0 RUNOFFHI
+  20   5     7   0 SALTHI
+  20   5     8   0 BDLOSSHI
+  20   5     9   0 DEFORESTHI
+  20   5    10   0 FORESTDECHI
+  20   5    11   0 FORESTDISHI
+  20   5    12   0 FORESTINVHI
+  20   5    13   0 WFIREHI
+  20   5    14   0 DESERTHI
+  20   5    15   0 MANLOSSHI
+  20   5    16   0 WETLOSSHI
+  20   5    17   0 CORALBHI
+  20   5    18   0 COMPSOILHI
+  20   5    19   0 SOILEROHI
+  20   5    20   0 COASTEROHI
+  20   5    21   0 PFLOSSHI
+  20   5    22   0 SAMINHI
+  20   5    23   0 SLRHI
+  20   5    24   0 EUTROPHI
+!
+! GRIB2 - TABLE 4.2-191-0 PARAMETERS FOR DISCIPLINE 191 CATEGORY 0
+!
+ 191   0     0   0 SPPT
+ 191   0     1   0 SPP
+ 191   0     2   0 SKEB
+ 191   0     3   0 STC
+ 191   0     4   0 SHUM
+ 191   0     5   0 STTP


### PR DESCRIPTION
This PR resolves issues #169 and #171 

A NCEP local use parameter, FOG (LWC), is added to [Table 4.2-0-6](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-6.shtml) for defining fog intensity in REFS products.  This parameter is needed for the upcoming REFSv1 implementation.

In addition, the NCEP GRIB2 tables have recently been updated to include 135 new parameters that have been added to the WMO tables over the past ~2 years.  For a complete listing of the newly added parameters, @BenjaminBlake-NOAA has a Google Doc listing the updates.  The params_grib2_tbl_new file is updated accordingly for these new fields.  There are no duplicate abbreviations with one exception, PRATE.  The current PRATE variable in [Table 4.2-0-1](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-1.shtml) (moisture) has been deprecated and should be replaced with PRATE in [Table 4.2-0-15](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-15.shtml) (radar).  Since PRATE in Table 4.2-0-15 is listed below the deprecated entry, the correct PRATE parameter will be used by UPP for any new operational implementations going forward.  This update should be included with the upcoming RRFSv1 implementation.