### PR TITLE
Update NCEP abbreviations for PRATE in Tables 4.2-0-15 and 4.2-0-16

### DIFF
--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -1011,9 +1011,9 @@
    0   1   240   1 PRATE10MIN
    0   1   238   1 PRATE1MIN
    0   1   239   1 PRATE5MIN
-   0  16     6   0 PRATEF
+   0  16     6   0 PRATEFRAD
+   0  15    17   0 PRATERAD
    0   1     7   0 PRATE
-   0  15    17   0 PRATE
    4   0     4   0 PRATMP
    0  15     5   0 PREC
    0   3    13   0 PRESALT

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -815,7 +815,7 @@
    0  15    15   0 HSR
    0  15    16   0 HSRHT
 !  Added new parameters on 10/1/2025
-   0  15    17   0 PRATE
+   0  15    17   0 PRATERAD
    0  15    18   0 RQI
    0  15    19   0 RDQF
 !  NCEP Local use
@@ -831,7 +831,7 @@
    0  16     4   0 REFD
    0  16     5   0 REFC
 !  Added new parameters on 10/1/2025
-   0  16     6   0 PRATEF
+   0  16     6   0 PRATEFRAD
 !  NCEP Local use
    0  16   192   1 REFZR
    0  16   193   1 REFZI


### PR DESCRIPTION
This PR is a follow up PR to #172 is related to the new PRATE parameters.

After some discussion with Jeff Ator and Wen Meng of EMC, we decided that we will continue to use the current definition of PRATE in Table 4.2-0-1 (moisture) for RRFSv1.  Even though a parameter may be listed as deprecated by the WMO, that doesn't necessarily mean that all users must stop using this parameter immediately.  PRATE (moisture) is already included in many of our models at NCEP so this change would affect many users.

In this PR, the PRATE abbreviations (for NCEP use) for the new WMO PRATE parameters added to Tables 4.2-0-15 and 4.2-0-16 are updated so that there are no duplicate entries.

@Hang-Lei-NOAA If these changes look good to you, could you include them in your g2tmpl/1.17.0?  Thank you!