### PR TITLE
ENH: Add the fixed surface type for the stratopause

### DIFF
--- a/src/grib2_all_tables_module.F90
+++ b/src/grib2_all_tables_module.F90
@@ -466,6 +466,7 @@ module grib2_all_tables_module
   data table4_5(124) /fixed_surface_types('road_lev',187)/
   data table4_5(125) /fixed_surface_types('melt_pond_top_surf',188)/
   data table4_5(126) /fixed_surface_types('melt_pond_bottom_surf',189)/
+  data table4_5(127) /fixed_surface_types('stratopause',36)/
   !
   !
   type type_of_ens_fcst

--- a/tests/test_all_key_tables.F90
+++ b/tests/test_all_key_tables.F90
@@ -566,6 +566,8 @@ program test_all_tables
   if (val1 .ne. 188) stop 9
   call get_g2_fixedsurfacetypes('melt_pond_bottom_surf', val1, ierr)
   if (val1 .ne. 189) stop 9
+  call get_g2_fixedsurfacetypes('stratopause', val1, ierr)
+  if (val1 .ne. 36) stop 9
   call get_g2_fixedsurfacetypes('xxx', val1, ierr)
   if (ierr .ne. 9) stop 9
 


### PR DESCRIPTION
Value taken from:
https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-5.shtml

I think this got added by WMO a bit ago (likely [here](https://github.com/wmo-im/GRIB2/issues/292) for the discussion and [here](https://github.com/wmo-im/GRIB2/pull/303/files#diff-7739d807494561f05367b928184bd6c59b7e5f725a9d261d087f54d9787c287d) for the changes).

I haven't really looked at the stratopause yet, but there seems to be a push to keep this repository current with the NCEP tables.