### PR TITLE
Add WMO GRIB2 parameters from V36 update, conditional intensity groups

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -16,7 +16,7 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-12
+      FC: gfortran-13
       CC: clang   # ✅ use Apple's clang for C
       CXX: clang++  # ✅ also set C++ compiler if needed
       

--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -314,6 +314,7 @@
    0   1    48   0 CWP
    1   1   195   1 CWR
    0   1   166   0 CWVF
+   1   0    24   0 DARVERVEL
    0  19    41   0 DBHEIGHT
   10   4   195   1 DBSS
   20   4     1   0 DBURSTHI
@@ -504,6 +505,7 @@
   10   0    81   0 FCVOCEAN
    2   4    32   0 FDLMC
    3   5     3   0 FDNSSTMP
+   2   4    43   0 FDPROB
    2   4    11   0 FDSRTE
    2   4    34   0 FDWMC
    1   0     0   0 FFLDG
@@ -593,6 +595,7 @@
    0   4     3   0 GRAD
    2   0    49   0 GRASSCOV
    0   7    17   0 GRDRN
+   1   0    22   0 GRFR
    0   1    32   0 GRLE
    2   0    60   0 GROSSFLUX
    3   6     1   0 GSOLEXP
@@ -606,6 +609,7 @@
    1   0     8   0 GWUPS
    0   1   236   1 HAILAC
   20   4    36   0 HAILHI
+   0  19    52   0 HAILKEF
    0   1    71   0 HAILMXR
    0  19   198   1 HAILPROB
    0   1    73   0 HAILPR
@@ -679,6 +683,7 @@
    1   2     5   0 ICTKIL
    2   0   207   1 ICWAT
    2   4    18   0 IGNCOMP
+   2   4    44   0 IGNLTNG
   20   4     9   0 IJFLDHI
    0   1    20   0 ILIQW
   10   0    27   0 IMFTSW
@@ -738,6 +743,9 @@
    2   3    10   0 LIQVSM
    2   4    27   0 LLFL
    0  15     4   0 LMAXBR
+   0  16     7   0 LMAXPRATEF
+   0  15    20   0 LMAXPRATE
+   0  16     8   0 LMAXREF
    4   7     0   0 LMBINT
    0   3   210   1 LMH
    0   2   218   1 LMV
@@ -750,6 +758,7 @@
    0  13   194   1 LPMTF
    0   3   201   1 LPSX
    0   3   202   1 LPSY
+   0  20    19   0 LRATEOH
    0   0   195   1 LRGHR
    0   1   217   1 LRGMR
    2   0   212   1 LSOIL
@@ -785,6 +794,7 @@
    0   1    28   0 MAXAH
    0   2   221   1 MAXDVV
    0   2    21   0 MAXGUST
+   0   1   171   0 MAXHAIL
    0  16   199   1 MAXREFC
    0  16   198   1 MAXREF
    0   1    27   0 MAXRH
@@ -805,6 +815,7 @@
   10   0    74   0 MDTSWEL
   10   0    75   0 MDWWAVE
    3   2    30   0 MEACST
+   0   1   170   0 MEANHAIL
    2   4    39   0 MEANHGTINJ
   20   0     1   0 MEANRTMP
    0  19    44   0 MEANVGRTL
@@ -1124,6 +1135,7 @@
   20   5     6   0 RUNOFFHI
   10   3   206   1 RUNUP
    1   2    21   0 RVERAR
+   1   0    23   0 RVERFLDPS
    1   2    20   0 RVERFR
    1   0    17   0 RVEROW
    1   0    11   0 RVERSW
@@ -1606,6 +1618,7 @@
    2   0    57   0 TYPLOVEG
    0   3    16   0 U-GWD
    0   3   194   1 U-GWD
+  10   0   103   0 UASMF
    0   4    57   0 UBALBDIRG
   10   1   194   1 UBARO
    0   3    31   0 UCLSPRS
@@ -1663,6 +1676,7 @@
    0   3   195   1 V-GWD
    0  19   232   1 VAFTD
    0   1     4   0 VAPP
+  10   0   104   0 VASMF
   10   1   195   1 VBARO
    0   4   200   1 VBDSF
    0   4   201   1 VDDSF
@@ -1805,6 +1819,7 @@
    0   3    45   0 WOBT
    2   0    42   0 WRDRATE
    2   0    33   0 WROD
+   1   0    21   0 WSE
   10   0   192   1 WSTP
   10   0   101   0 WSTRICEX
   10   0   102   0 WSTRICEY

--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -187,6 +187,10 @@
   10   2    12   0 CICES
    0   6     0   0 CICE
    0  19   208   1 CIFLT
+   0  19   224   1 CIGHAIL
+   0  19   226   1 CIGSVR
+   0  19   223   1 CIGTOR
+   0  19   225   1 CIGWIND
    0   1    82   0 CIMIXR
    0  20    66   0 CINCLDSP
    0  20    69   0 CINCSLSP

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -30,6 +30,7 @@
 !2025-10-01         B. BLAKE         Added new parameters, and
 !                                    new tables 4.2-2-7,4.2-20-4,
 !                                    4.2-20-5,4.2-191-0
+!2025-11-24         B. BLAKE         Added new parameters
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -279,6 +280,9 @@
 !  Added New Parameters 12/15/2023
    0   1   168   0 SSPFHW
    0   1   169   0 TCISSPFHW
+!  Added new parameters on 11/24/2025
+   0   1   170   0 MEANHAIL
+   0   1   171   0 MAXHAIL
 !  NCEP Local use
    0   1   192   1 CRAIN
    0   1   193   1 CFRZR
@@ -818,6 +822,8 @@
    0  15    17   0 PRATERAD
    0  15    18   0 RQI
    0  15    19   0 RDQF
+!  Added new parameters on 11/24/2025
+   0  15    20   0 LMAXPRATE
 !  NCEP Local use
 !  Added new parameters on 6/11/2025
    0  15   192   1 RADARVIL
@@ -832,6 +838,9 @@
    0  16     5   0 REFC
 !  Added new parameters on 10/1/2025
    0  16     6   0 PRATEFRAD
+!  Added new parameters on 11/24/2025
+   0  16     7   0 LMAXPRATEF
+   0  16     8   0 LMAXREF
 !  NCEP Local use
    0  16   192   1 REFZR
    0  16   193   1 REFZI
@@ -951,6 +960,8 @@
    0  19    50   0 CITEDR
 !  Added new parameters on 10/1/2025
    0  19    51   0 VISPCP
+!  Added new parameters on 11/24/2025
+   0  19    52   0 HAILKEF
 !  NCEP Local use
    0  19   192   1 MXSALB
    0  19   193   1 SNFALB
@@ -1018,6 +1029,8 @@
    0  20    17   0 MSSRWETA
 !  Added new parameters 10/20/2023
    0  20    18   0 POTHPH
+!  Added new parameters on 11/24/2025
+   0  20    19   0 LRATEOH
 !
    0  20    50   0 AIA
    0  20    51   0 CONAIR
@@ -1182,6 +1195,11 @@
    1   0    18   0 FLDPOW
    1   0    19   0 FLDPATHOW
    1   0    20   0 WATSURF
+!  Added new parameters on 11/24/2025
+   1   0    21   0 WSE
+   1   0    22   0 GRFR
+   1   0    23   0 RVERFLDPS
+   1   0    24   0 DARVERVEL
 !  NCEP Local use
    1   0   192   1 BGRUN
    1   0   193   1 SSRUN
@@ -1467,6 +1485,9 @@
    2   4    40   0 HGTINJ
    2   4    41   0 HGTPLUMEB
    2   4    42   0 HGTPLUMET
+!  Added new parameters on 11/24/2025
+   2   4    43   0 FDPROB
+   2   4    44   0 IGNLTNG
 !
 !  Added new Discipline 2 category 5 in 8/26/2015
 !
@@ -1930,11 +1951,14 @@
   10   0    97   0 STMWAVE
 !  New parameters added 07/17/2024
   10   0    98   0 GODAPEAK
-! Added new parameters on 10/1/2025
+!  Added new parameters on 10/1/2025
   10   0    99   0 BFI2D
   10   0   100   0 CTCORR
   10   0   101   0 WSTRICEX
   10   0   102   0 WSTRICEY
+!  Added new parameters on 11/24/2025
+  10   0   103   0 UASMF
+  10   0   104   0 VASMF
 !  NCEP Local use
   10   0   192   1 WSTP
 !  Added parameter in 8/26/2015

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -31,6 +31,7 @@
 !                                    new tables 4.2-2-7,4.2-20-4,
 !                                    4.2-20-5,4.2-191-0
 !2025-11-24         B. BLAKE         Added new parameters
+!2026-01-29         B. BLAKE         Added new parameters
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -994,6 +995,11 @@
    0  19   220   1 SVRTS
    0  19   221   1 PROCON
    0  19   222   1 CONVP
+!  Added new parameters on 1/29/2026
+   0  19   223   1 CIGTOR
+   0  19   224   1 CIGHAIL
+   0  19   225   1 CIGWIND
+   0  19   226   1 CIGSVR
    0  19   232   1 VAFTD
    0  19   233   1 ICPRB
    0  19   234   1 ICSEV


### PR DESCRIPTION
The following 15 WMO parameters were added with the GRIB2 V36 update on November 19, 2025:

- Mean Mass Diameter of Hail (MEANHAIL) - Table 4.2-0-1
- Estimated Maximum Diameter of Hail (MAXHAIL) - Table 4.2-0-1
- Layer Maximum Precipitation Rate (LMAXPRATE) - Table 4.2-0-15
- Layer Maximum Precipitation Rate (LMAXPRATEF) - Table 4.2-0-16
- Layer Maximum Reflectivity (LMAXREF) - Table 4.2-0-16
- Hail Kinetic Energy Flux (HAILKEF) - Table 4.2-0-19
- Loss Rate Due to Reaction with Hydroxyl Radical (LRATEOH) - Table 4.2-0-20
- Water Surface Elevation (WSE) - Table 4.2-1-0
- Groundwater Return Flow Rate (GRFR) - Table 4.2-1-0
- River and Floodplain Storage (RVERFLDPS) - Table 4.2-1-0
- Depth Averaged River Velocity (DARVERVEL) - Table 4.2-1-0
- Probability of Fire Detection (FDPROB) - Table 4.2-2-4
- Probability of Ignition from Lightning (IGNLTNG) - Table 4.2-2-4
- U-Component of Atmospheric Surface Momentum Flux (UASMF) - Table 4.2-10-0
- V-Component of Atmospheric Surface Momentum Flux (VASMF) - Table 4.2-10-0

In addition, the following NCEP local use GRIB2 IDs were added to [Table 4.2-0-19](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-19.shtml) for their upcoming implementation at SPC:

Tornado Conditional Intensity Groups (CIGTOR)
Hail Conditional Intensity Groups (CIGHAIL)
Wind Conditional Intensity Groups (CIGWIND)
Total Severe Conditional Intensity Groups (CIGSVR)

This PR adds these new parameters to g2tmpl and resolves issues #176 and #180 