### PR TITLE
CI: add cron's and workflow_dispatch's

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -20,9 +20,9 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-12
-      CC: clang   # ✅ use Apple's clang for C
-      CXX: clang++  # ✅ also set C++ compiler if needed
+      FC: gfortran-14
+      CC: clang
+      CXX: clang++
       
     steps:
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -43,8 +43,7 @@ jobs:
         use-repo-cache: true
         spack-compiler: gcc
         repo-cache-key-suffix: ${{ matrix.os }}-1
-        spack-externals: cmake gmake
-        use-common-build-cache: false
+        use-common-build-cache: true
 
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run biweekly
+    - cron: '0 0 1 * *'
+    - cron: '0 0 15 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:


### PR DESCRIPTION
This PR updates CI workflows to run on cron's: biweekly for 'developer' workflow, monthly for the rest. It also adds workflow_dispatch triggers to enable running workflows manually.

Part of https://github.com/NOAA-EMC/NCEPLIBS/issues/237