### PR TITLE
Add MIXL to Table 4.2-2-0

### DIFF
--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -831,6 +831,7 @@
    0  19    45   0 MINVGRTL
    0  19     3   0 MIXHT
    0  19   204   1 MIXLY
+   2   0   240   1 MIXL
    0   1     2   0 MIXR
   10   4    52   0 MLD
    0   7   212   1 MLFC

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -32,6 +32,7 @@
 !                                    4.2-20-5,4.2-191-0
 !2025-11-24         B. BLAKE         Added new parameters
 !2026-01-29         B. BLAKE         Added new parameters
+!2026-03-03         B. BLAKE         Added new parameter
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -1382,6 +1383,8 @@
    2   0   237   1 EIWATER
    2   0   238   1 PLANTTR
    2   0   239   1 SOILSE
+!  Added new parameters on 3/3/2026
+   2   0   240   1 MIXL 
 !
 ! GRIB2 - TABLE 4.2-2-1 PARAMETERS FOR DISCIPLINE 2 CATEGORY 1
 !


### PR DESCRIPTION
This PR resolves issue #181 

A NCEP local use parameter, MIXL, is added to [Table 4.2-2-0](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-2-0.shtml) for defining a generalized mixing length scale (i.e., not associated with the Blackadar formulation) for RRFS-MPAS products.