### PR TITLE
Add 8 new parameters for WMO GRIB2 v37 update; add MIXL to Table 4.2-2-0

### DIFF
--- a/src/params_grib2_tbl_new
+++ b/src/params_grib2_tbl_new
@@ -439,6 +439,9 @@
    0   1   139   0 EFARSNOW
    0  18    23   0 EFFDOSER
   20   0     5   0 EFFTEMP
+   0   7    27   0 EFHLLM
+   0   7    26   0 EFHLRM
+   0   7    25   0 EFHL
    0   7   204   1 EFHL
    0   1   129   0 EFRCCWAT
    0   1   131   0 EFRCICE
@@ -461,6 +464,7 @@
    0 191   197   1 ELONN
    0 191   193   1 ELON
    0  20    76   0 EMISFLX
+   0  20    21   0 EMISPOT
    2   0    62   0 EMISS
   10   0    93   0 EMIWAVE
    0   1   211   1 EMNP
@@ -641,6 +645,8 @@
    0  19    32   0 HIFREL
    2   4     2   0 HINDEX
    2   0    54   0 HIVEGCOV
+   0   7    24   0 HLCYLM
+   0   7    23   0 HLCYRM
    0   7     8   0 HLCY
    0  18    16   0 HMXACON
    2   7     0   0 HNETFLUX
@@ -831,6 +837,7 @@
    0  19    45   0 MINVGRTL
    0  19     3   0 MIXHT
    0  19   204   1 MIXLY
+   2   0   240   1 MIXL
    0   1     2   0 MIXR
   10   4    52   0 MLD
    0   7   212   1 MLFC
@@ -996,6 +1003,7 @@
    4   5     1   0 PHASE
    0   4    60   0 PHOARFCS
    0   4    10   0 PHOTAR
+   0  20    20   0 PHRATE
    0   1   122   0 PIIDX
    0  21    21   0 PILENERGY
    3   0     8   0 PIXST
@@ -1808,6 +1816,7 @@
    4   8     3   0 WHTRAD
    2   0    26   0 WILT
    2   0   201   1 WILT
+   0   2    70   0 WINDERO
    0   2    33   0 WINDF
   20   4    60   0 WINDHI
   20   3     2   0 WINDPCAP

--- a/src/params_grib2_tbl_new.text
+++ b/src/params_grib2_tbl_new.text
@@ -32,6 +32,8 @@
 !                                    4.2-20-5,4.2-191-0
 !2025-11-24         B. BLAKE         Added new parameters
 !2026-01-29         B. BLAKE         Added new parameters
+!2026-03-03         B. BLAKE         Added new parameter
+!2026-06-11         B. BLAKE         Added new parameters
 !
 !
 !GRIB2 parameter table for all disciplines and categories
@@ -422,6 +424,8 @@
 !  Added new parameters on 10/1/2025
    0   2    68   0 CNVGUST
    0   2    69   0 TURBGUST
+!  Added new parameters on 6/11/2026
+   0   2    70   0 WINDERO
 !  NCEP Local use
    0   2   192   1 VWSH
    0   2   193   1 MFLX
@@ -742,6 +746,12 @@
 !  Added new parameters on 10/1/2025
    0   7    21   0 SSI
    0   7    22   0 RMOL
+!  Added new parameters on 6/11/2026
+   0   7    23   0 HLCYRM
+   0   7    24   0 HLCYLM
+   0   7    25   0 EFHL
+   0   7    26   0 EFHLRM
+   0   7    27   0 EFHLLM
 !  NCEP Local use
    0   7   192   1 LFTX
    0   7   193   1 4LFTX
@@ -1037,6 +1047,9 @@
    0  20    18   0 POTHPH
 !  Added new parameters on 11/24/2025
    0  20    19   0 LRATEOH
+!  Added new parameters on 6/11/2026
+   0  20    20   0 PHRATE
+   0  20    21   0 EMISPOT
 !
    0  20    50   0 AIA
    0  20    51   0 CONAIR
@@ -1382,6 +1395,8 @@
    2   0   237   1 EIWATER
    2   0   238   1 PLANTTR
    2   0   239   1 SOILSE
+!  Added new parameter on 3/3/2026
+   2   0   240   1 MIXL
 !
 ! GRIB2 - TABLE 4.2-2-1 PARAMETERS FOR DISCIPLINE 2 CATEGORY 1
 !


### PR DESCRIPTION
This PR resolves issues #181 and #183 

8 new parameters were added as part of the WMO GRIB2 v37 implementation:
[Table 4.2-0-2](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-2.shtml)
- Wind Speed Threshold for Wind Erosion (WINDERO)

[Table 4.2-0-7](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-7.shtml)
- Storm Relative Helicity - Right Moving Storm (HLCYRM)
- Storm Relative Helicity - Left Moving Storm (HLCYLM)
- Effective Storm Relative Helicity - Mean Flow (EFHL)
- Effective Storm Relative Helicity - Right Moving Storm (EFHLRM)
- Effective Storm Relative Helicity - Left Moving Storm (EFHLLM)

[Table 4.2-0-20](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-20.shtml)
- Photolysis Rate (PHRATE)
- Emission Potential (EMISPOT)

In addition, mixing length scale (MIXL) was added several months ago as an NCEP local use variable to [Table 4.2-2-0](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-2-0.shtml).  Since my previous PR was not merged that change is also included here.